### PR TITLE
Development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,99 +1,35 @@
 # RegulonDB HT ETL
 
-This version solves the changes on RegulonDB 13.5.0
+This version solves the changes on RegulonDB 13.6.0
 
-## [2.0.0](https://github.com/regulondbunam/RegulonDBHT-ETL/releases/tag/2.0.0) - 2024-10-24
-New updates in the input data requires constantly software updates and code was not properly modulated, now to avoid future problems in maintenance we decide to rework the full code and make it more dev friendly.
+## [2.0.1](https://github.com/regulondbunam/RegulonDBHT-ETL/releases/tag/2.0.1) - 2025-03-18
+
 
 ### Added
 
-- **Feb, 2024**
-- Publications from datasets pmids can be extracted.
-- Source Serie object.
-- ObjectTested object.
-- ObjectTested Genes.
-- Sample object.
-- LinkedDatasets object.
-- ReleaseControl object.
-- Temporal ID property.
-- Reference Genome property.
-- Assembly Genome ID property.
-- Five Prime Enrichment property.
-- Experiment Condition property.
-- Cut Off property.
-- Public Notes property.
-- Source Reference Genome property.
-- Collection Data object property.
-- Metadata object property.
-- **Mar, 2024**
-- Final JSON file are generated with respective names.
-- External Reference property added to dataset object.
-- **Aug, 2024**
-- Metadata objects now have an ID.
-- New utility function added, find_many_in_dict_list(), Finds dictionaries in a dictionary List by certain key.
-- **Oct, 2024**
-- Growth Conditions function that process GC from dataset metadata.
-- Objects Tested now have AbbName property.
+- Without changes.
 
 ### Changed
 
-- **Feb, 2024**
-- New code structure is now implemented.
-- **Mar, 2024**
-- DB Links field contains DBName and DBLink
-- **Apr, 2024**
-- Properties that returns a dictionary now are assembled in an upper level.
-- Authors Data is processed in the dataset object.
-- Uniformized Data is processed in the dataset object, tfBinfings (sites, peaks) ready.
-- **May, 2024**
-- Uniformized Data is processed in the dataset object, TUs ready.
-- Uniformized Data is processed in the dataset object, TSS ready.
-- Uniformized Data is processed in the dataset object, TTS ready.
-- Uniformized Data is processed in the dataset object, multiple sources ready.
-- Utils module cleaned, repeated functions, functions that must be classes and unused functions.
-- Added modules for Gene Expression processing with the uniformized data.
-- Added class Summary, there are properties to define that need to be reviewed by the project manager.
-- **Aug, 2024**
-- GeneExpression's IDs are now more readable, removed properties without values.
-- Snakemake Config files modified to adjust for new project schema.
-- **Oct, 2024**
-- Update Gene Expression Temp ID and ID format.
+- AuthorsData, handle commas in tsv files, now .bed files can be readed.
+- RNA collection now generates metadata info.
+- Growth Conditions can be loaded from DatasetMetadata file and can handle arrays of GC.
+- Some readed files starts with an empty colum, FIXED.
+- Experiments IDs can be readed correctly.
+- Peaks score property error in reading, FIXED.
+- NLP Growth Conditions, adjust to have more than one term.
 
 ### Deprecated
 
-- Old code structure.
+- Without changes.
 
 ### Removed
 
-- **May, 2024**
-- src/ht_etl/dataset_metadata.py
-- src/ht_etl/peaks_datasets.py
-- src/ht_etl/sites_dataset.py
-- src/ht_etl/tss_datasets.py
-- src/ht_etl/tts_datasets.py
-- src/ht_etl/tu_datasets.py
-- src/ht_etl/gene_expression_dataset_metadata.py
-- src/ht_etl/gene_exp_datasets.py
-- src/ht_etl/nlp_growth_conditions.py
+- Without changes.
 
 ### Fixed
 
-- **Feb, 2024**
-- ObjectTested returned null objects that can't be read and have to be a list.
-- ObjectTested tried to process TF that doesn't exist.
-- **Mar,2024**
-- Sample Replicates IDs and Linked Datasets now are List of List of IDs.
-- **Aug, 2024**
-- TUs objects were missing name. Added.
-- Sites' left and right position were String instead of Integer. Fixed
-- NLP_GC's terms were not object arrays, temporal_id were generating wrong, dataset ids does not match with correspond Dataset ID. Fixed.
-- GeneExpression's temporal_id were generating wrong, dataset ids does not match with correspond Dataset ID. Fixed.
-- Uniformized_Data Domain Objects Base were not adding dataset_ids. Fixed.
-- Uniformized_Data Peaks and Sites were not adding dataset_ids. Fixed
-- Uniformized_Data TSS, TTS and TU LeftEnd and RightEnd properties were wrong written. Fixed
-- ObjectTested externalCrossReferenceID property were wrong written. Fixed
-- Genes were not generating correctly geneNames. Fixed
-- Many JSON files were generated with incorrect properties. Fixed
+- Without changes.
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 </p>
 
 [![License](https://img.shields.io/badge/license-APACHE-brightgreen?style=plastic)](LICENSE)
-[![RegulonDBVersion](https://img.shields.io/badge/RegulonDB_version-13.5-blue?style=plastic)](https://regulondb.ccg.unam.mx/)
+[![RegulonDBVersion](https://img.shields.io/badge/RegulonDB_version-13.6-blue?style=plastic)](https://regulondb.ccg.unam.mx/)
 [![EcocycVersion](https://img.shields.io/badge/last_Ecocyc_version_tested-28.5-red?style=plastic)](https://ecocyc.org/)
-[![Status](https://img.shields.io/badge/release_2.0.0-yellowgreen?style=plastic)](CHANGELOG.md)
+[![Status](https://img.shields.io/badge/release_2.0.1-yellowgreen?style=plastic)](CHANGELOG.md)
 
 This software is used for the extraction and processing of diferent collections of HT Datasets.
 
@@ -53,7 +53,8 @@ RegulonDB Ecocyc Extractor is [Apache 2.0 licensed](LICENSE).
 
 **Accessibility**
 
-<!--  - [ ] Unique DOI [identifier](http://....) (Please update identifier and link) -->
+<!--- [ ] Unique DOI [identifier](http://....) (Please update identifier and link) --->
+
 - [x] Version control system
 
 **Documentation**

--- a/Snakefile
+++ b/Snakefile
@@ -26,7 +26,7 @@ rule ht_extractor_workflow:
         "../logs/ht_extractor_log.log"
     run:
         shell('python ../log_cleaner/log_cleaner.py')
-        
+
 rule ht_extractor:
     params:
         main_path = ht_extractor_config["main_path"],
@@ -76,7 +76,7 @@ rule data_validator:
     shell:
         "python {params.main_path} -i {params.data} -s {params.schemas} -v {params.valid_data} -iv {params.invalid_data} -l {params.log} -sp"
 
-rule data_validator_ge:
+"""rule data_validator_ge:
     params:
         main_path = validation_config["main_path"],
         data = validation_config["raw_data_ge"],
@@ -91,7 +91,7 @@ rule data_validator_ge:
     priority: 8
     shell:
         "python {params.main_path} -i {params.data} -s {params.schemas} -v {params.valid_data} -iv {params.invalid_data} -l {params.log} -sp"
-
+"""
 rule create_identifiers:
     params:
         main_path = create_identifiers_config["main_path"],
@@ -164,7 +164,7 @@ rule data_uploader:
     shell:
         "python {params.main_path} -i {params.valid_data} -u {params.url} -db {params.db} -l {params.log}"
 
-rule data_uploader_ge:
+"""rule data_uploader_ge:
     params:
         main_path = data_upload_config["main_path"],
         valid_data = data_upload_config["gene_expression"],
@@ -175,6 +175,7 @@ rule data_uploader_ge:
         "../logs/data_uploader_log/data_uploader_log.log"
     conda:
         "envs/db_dependencies.yaml"
-    priority: 4
+    priority: 3
     shell:
         "python {params.main_path} -i {params.valid_data} -u {params.url} -db {params.db} -l {params.log}"
+"""

--- a/config/config.json
+++ b/config/config.json
@@ -2,9 +2,9 @@
   "url": "mongodb://127.0.0.1:27017",
   "db": "regulondbht",
   "organism": "ECOLI",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "source": "EcoCyc",
-  "source_version": 4.0,
+  "source_version": 4.1,
   "ptools_config": {
     "compose_file": "../pathway-tools-docker/docker-compose.yml",
     "dotenv_file": "../pathway-tools-docker/.env"
@@ -24,36 +24,37 @@
     "raw_data": "../RawData/",
     "raw_data_ge": "../RawData/gene_expression",
     "schemas": "../../RegulonDBHT-Model/jsonSchemas/htCollections/",
-    "verified_data": "../VerifiedData",
+    "verified_data": "../VerifiedData/",
     "verified_data_ge": "../VerifiedPersistentIdentifiers/gene_expression/",
-    "invalid_data": "../InvalidData",
+    "invalid_data": "../InvalidData/",
     "log_dir": "../logs/validation_log/"
   },
   "create_identifiers_config": {
     "main_path": "../../../Libs/data-release-tools/src/create_identifiers/",
-    "verified_data": "../VerifiedData",
+    "verified_data": "../VerifiedData/",
     "sub_verified_data": "../VerifiedData/subClasses",
     "log_dir": "../logs/create_identifiers_log/"
   },
   "replace_identifiers_config": {
     "main_path": "../../../Libs/data-release-tools/src/replace_identifiers/",
-    "verified_data": "../VerifiedData",
-    "persistent_ids": "../PersistentIdentifiers",
+    "verified_data": "../VerifiedData/",
+    "persistent_ids": "../PersistentIdentifiers/",
     "log_dir": "../logs/replace_identifiers_log/"
   },
   "revalidation_config": {
     "main_path": "../../../Libs/data-release-tools/src/data_validator/",
-    "persistent_ids": "../PersistentIdentifiers",
+    "persistent_ids": "../PersistentIdentifiers/",
     "schemas": "../../RegulonDBHT-Model/jsonSchemas/htCollections/",
-    "verified_persistent_ids": "../VerifiedPersistentIdentifiers",
-    "invalid_data": "../InvalidData",
+    "verified_persistent_ids": "../VerifiedPersistentIdentifiers/",
+    "invalid_data": "../InvalidData/",
     "log_dir": "../logs/re_validation_log/"
   },
   "data_upload_config": {
     "gene_expression": "../VerifiedPersistentIdentifiers/gene_expression/",
+    "raw_data_ge": "../RawData/gene_expression",
     "dap_2023": "../RawData/",
     "main_path": "../../../Libs/data-release-tools/src/data_uploader/",
-    "verified_persistent_ids": "../VerifiedPersistentIdentifiers",
+    "verified_persistent_ids": "../VerifiedPersistentIdentifiers/",
     "log_dir": "../logs/data_uploader_log/"
   }
 }

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -22,10 +22,10 @@ def run(**kwargs):
     """
     Run function, controls program functions and generates output files.
 
-    Param
-        kwargs.datasets_record_path, String, Datasets record path.
-        kwargs.output_path, String, Output directory path.
-        kwargs.organism, String, Organism name.
+    Args:
+        kwargs.datasets_record_path: String, Datasets record path.
+        kwargs.output_path: String, Output directory path.
+        kwargs.organism: String, Organism name.
     """
     print(f"Reading data from {kwargs.get('datasets_record_path', None)}")
     logging.info(f"Reading data from {kwargs.get('datasets_record_path', None)}")
@@ -62,7 +62,7 @@ def run(**kwargs):
     for dataset_obj in datasets_objs:
         dataset_obj_dict = dataset_obj.dataset
         dataset_list.append(dataset_obj_dict)
-        if dataset_obj.metadata and kwargs.get('dataset_type', None) != constants.RNA:
+        if dataset_obj.metadata: # and kwargs.get('dataset_type', None): != constants.RNA:
             found_metadata = utils.find_one_in_dict_list(
                 dict_list=metadata_list,
                 key_name='_id',
@@ -72,7 +72,7 @@ def run(**kwargs):
                 metadata_list.append(dataset_obj.metadata)
             else:
                 new_ref = dataset_obj.metadata.get('reference', None)
-                if new_ref:
+                if new_ref and kwargs.get('dataset_type', None) != constants.RNA:
                     last_ref = found_metadata.get('reference')
                     if new_ref not in last_ref:
                         last_ref.extend(new_ref)

--- a/src/ht_etl/domain/authors_data.py
+++ b/src/ht_etl/domain/authors_data.py
@@ -96,17 +96,28 @@ class AuthorsData(object):
                 f'Reading Author\'s Data files {excel_path}')
             return author_raw
         elif os.path.isfile(excel_path) and excel_path.endswith('.tsv'):
+            # TODO: quitar las , de header?
             raw = file_manager.get_author_data_frame_tsv(str(excel_path))
             raw = raw.loc[:, ~raw.columns.str.contains('^Unnamed')]
-            author_raw = raw.to_csv(encoding='utf-8', index=True)
+            raw = raw.map(lambda x: str(x).replace(',', ';'))
+            author_raw = raw.to_csv(encoding='utf-8', index=False)
             author_raw = author_raw.replace(',,,,,#', '#')
+            logging.info(
+                f'Reading Author\'s Data files {excel_path}')
+            return author_raw
+        elif os.path.isfile(excel_path) and excel_path.endswith('.bed'):
+            raw = file_manager.get_author_data_frame_tsv(str(excel_path))
+            raw = raw.loc[:, ~raw.columns.str.contains('^Unnamed')]
+            author_raw = raw.to_csv(encoding='utf-8', index=False)
+            author_raw = author_raw.replace(',,,,,#', '#')
+            author_raw = author_raw.lstrip('#')
             logging.info(
                 f'Reading Author\'s Data files {excel_path}')
             return author_raw
         elif os.path.isfile(excel_path) and excel_path.endswith('.txt'):
             raw = file_manager.get_author_data_frame_tsv(str(excel_path))
             raw = raw.loc[:, ~raw.columns.str.contains('^Unnamed')]
-            author_raw = raw.to_csv(encoding='utf-8', index=True)
+            author_raw = raw.to_csv(encoding='utf-8', index=False)
             author_raw = author_raw.replace(',,,,,#', '#')
             logging.info(
                 f'Reading Author\'s Data files {excel_path}')

--- a/src/ht_etl/domain/linked_dataset.py
+++ b/src/ht_etl/domain/linked_dataset.py
@@ -69,9 +69,8 @@ class LinkedDataset(object):
             logging.warning('No sample_experimental_replicate_ids provided')
             return sample_replicates
         sample_replicate_ids = sample_replicate_ids.replace('\t', '')
-        sample_replicate_ids = sample_replicate_ids.split('] [')
-        for sample_replicate_id in sample_replicate_ids:
-            sample_replicate_id = sample_replicate_id.replace('[', '').replace(']', '')
-            sample_replicate_id = sample_replicate_id.replace(', ', ',').replace('  ', ',').replace(' ', ',').split(',')
-            sample_replicates.append(sample_replicate_id)
+
+        sample_replicate_ids = (sample_replicate_ids.replace(' ', '').replace('][', ',')
+                                .replace('[', '').replace(']', '').replace(';', ','))
+        sample_replicates.extend(sample_replicate_ids.split(','))
         return sample_replicates

--- a/src/ht_etl/domain/sample.py
+++ b/src/ht_etl/domain/sample.py
@@ -69,9 +69,8 @@ class Sample(object):
             logging.warning('No sample_replicate_ids provided')
             return sample_replicates
         sample_replicate_ids = sample_replicate_ids.replace('\t', '')
-        sample_replicate_ids = sample_replicate_ids.split('] [')
-        for sample_replicate_id in sample_replicate_ids:
-            sample_replicate_id = sample_replicate_id.replace('[', '').replace(']', '')
-            sample_replicate_id = sample_replicate_id.replace(', ', ',').replace('  ', ',').replace(' ', ',').split(',')
-            sample_replicates.append(sample_replicate_id)
+
+        sample_replicate_ids = (sample_replicate_ids.replace(' ', '').replace('][', ',')
+                                .replace('[', '').replace(']', '').replace(';',','))
+        sample_replicates.extend(sample_replicate_ids.split(','))
         return sample_replicates

--- a/src/ht_etl/domain/source_serie.py
+++ b/src/ht_etl/domain/source_serie.py
@@ -12,6 +12,15 @@ from src.ht_etl.sub_domain.series import Series
 
 
 class SourceSerie(object):
+    strategies = {
+        "chip-seq": "ChIP-seq",
+        "dapseq": "DAP",
+        "gselex-chip": "gSELEX-chip",
+        "chip-exo": "ChIP-exo",
+        "gselex": "gSELEX",
+        "rna-seq": "RNA-seq",
+        "5'race": "5' RACE",
+    }
     def __init__(self, **kwargs):
         # Params
         self.serie_id = kwargs.get('serie_id', None)
@@ -19,7 +28,7 @@ class SourceSerie(object):
         self.platform_id = kwargs.get('platform_id', None)
         self.platform_title = kwargs.get('platform_title', None)
         self.title = kwargs.get('title', None)
-        self.strategy = kwargs.get('strategy', None)
+        self.strategy_text = kwargs.get('strategy', None)
         self.method = kwargs.get('method', None)
         self.read_type = kwargs.get('read_type', None)
         self.source_db = kwargs.get('source_db', None)
@@ -27,10 +36,26 @@ class SourceSerie(object):
         # Local properties
 
         # Object properties
+        self.strategy = kwargs.get('strategy', None)
         self.source_series = kwargs.get('source_series', None)
         self.platform = kwargs.get('platform', None)
 
     # Local properties
+    @property
+    def strategy(self):
+        return self._strategy
+
+    @strategy.setter
+    def strategy(self, strategy_value=None):
+        if self.strategy_text:
+            strategy_value = self.strategy_text.replace(' ', '')
+            strategy_value = strategy_value.lower()
+            if strategy_value in self.strategies:
+                self._strategy = self.strategies[strategy_value]
+            else:
+                self._strategy = self.strategy_text
+        else:
+            self._strategy = self.strategy_text
 
     # Object properties
     @property

--- a/src/ht_etl/domain/uniformized_data/domain/nlp_growth_condition.py
+++ b/src/ht_etl/domain/uniformized_data/domain/nlp_growth_condition.py
@@ -17,7 +17,8 @@ class NLPGrowthCondition(Base):
     def __init__(self, **kwargs):
         super(NLPGrowthCondition, self).__init__(**kwargs)
         # Params
-
+        # TODO: build new class term to iterate terms property and get every single term, add extRef property and
+        #  citations (should it has RDB format?)
         # Local properties
         self.terms = kwargs.get("terms", None)
 

--- a/src/ht_etl/domain/uniformized_data/domain/peak.py
+++ b/src/ht_etl/domain/uniformized_data/domain/peak.py
@@ -44,7 +44,11 @@ class Peak(Base):
     @score.setter
     def score(self, score=None):
         if score is None:
-            score = float(self.data_row[4])
+            try:
+                score = float(self.data_row[4])
+            except ValueError:
+                # max_norm_fold_enrichment
+                score = float(self.data_row[7])
         self._score = score
 
     @property

--- a/src/ht_etl/domain/uniformized_data/sites.py
+++ b/src/ht_etl/domain/uniformized_data/sites.py
@@ -2,8 +2,6 @@
 TF Binding Sites object.
 Build uniformized data object for every dataset.
 """
-import os.path
-
 # standard
 
 # third party

--- a/src/ht_etl/domain/uniformized_data/uniformized_base.py
+++ b/src/ht_etl/domain/uniformized_data/uniformized_base.py
@@ -71,6 +71,14 @@ class Base(object):
                         ds_id,
                         f'{ds_id}_peaks.bed'
                     )
+                if self.sub_type == constants.PEAKS and ds_id and not self.serie_id:
+                    uniform_path = os.path.join(
+                        str(uniform_paths),
+                        ds_id,
+                        f'{ds_id}_peaks.bed'
+                    )
+
+                # TODO: New path format, uniformized_data/[ID_peaks.bed|ID_matrix.png|ID_heatmap.png]
             if self.type == constants.TUS:
                 if ds_id is None:
                     ds_id = self.dataset_id

--- a/src/libs/file_manager.py
+++ b/src/libs/file_manager.py
@@ -15,7 +15,7 @@ import pandas
 
 def validate_directories(data_path):
     """
-    Verify if the output path directories exists.
+    Verify if the directory path exists.
 
     Args:
         data_path: String, directories path.
@@ -23,8 +23,21 @@ def validate_directories(data_path):
     Returns:
         Rise IOError if not valid directory
     """
-    if not os.path.isdir(data_path):
+    if not data_path or not os.path.isdir(data_path):
         raise IOError("Please, verify '{}' directory path".format(data_path))
+
+def validate_file_path(data_path):
+    """
+    Verify if the file path exists.
+
+    Args:
+        data_path: String, file path.
+
+    Returns:
+        Rise IOError if not valid path
+    """
+    if not data_path or not os.path.isfile(data_path):
+        raise IOError("Please, verify '{}' file path".format(data_path))
 
 
 def set_log(log_path, log_name, log_date):

--- a/src/libs/file_manager.py
+++ b/src/libs/file_manager.py
@@ -178,7 +178,7 @@ def get_author_data_frame_tsv(filename: str) -> pandas.DataFrame:
     Returns:
         dataset_df: pandas.DataFrame, DataFrame with the Datasets Record Excel file data.
     """
-    dataset_df = pandas.read_csv(filename, sep='\t')
+    dataset_df = pandas.read_csv(filename, sep='\t', header=0, index_col=False)
     return dataset_df
 
 

--- a/src/libs/nlp_growth_conditions_utils.py
+++ b/src/libs/nlp_growth_conditions_utils.py
@@ -12,10 +12,11 @@ from src.ht_etl.domain.uniformized_data.domain.nlp_growth_condition import NLPGr
 from src.libs import constants
 
 
-def geo_nlp_gc_json_path(collection_path):
+def geo_nlp_gc_json_path(collection_path, file_name="metadata/srr_htregulondb_correct_full.json"):
     """
     Set path to geo-NLP Growth Conditions JSON.
     Args:
+        file_name:
         collection_path:
 
     Returns:
@@ -23,15 +24,16 @@ def geo_nlp_gc_json_path(collection_path):
     """
     json_path = os.path.join(
         collection_path,
-        "metadata/srr_htregulondb_correct_full.json"
+        file_name
     )
     return json_path
 
 
-def no_geo_nlp_gc_json_path(collection_path):
+def no_geo_nlp_gc_json_path(collection_path, file_name="metadata/no_geo_gc.json"):
     """
     Set path to NO-geo-NLP Growth Conditions JSON.
     Args:
+        file_name:
         collection_path:
 
     Returns:
@@ -39,7 +41,7 @@ def no_geo_nlp_gc_json_path(collection_path):
     """
     json_path = os.path.join(
         collection_path,
-        "metadata/no_geo_gc.json"
+        file_name
     )
     return json_path
 


### PR DESCRIPTION
# RegulonDB HT ETL

This version solves the changes on RegulonDB 13.6.0

## [2.0.1](https://github.com/regulondbunam/RegulonDBHT-ETL/releases/tag/2.0.1) - 2025-03-18


### Added

- Without changes.

### Changed

- AuthorsData, handle commas in tsv files, now .bed files can be readed.
- RNA collection now generates metadata info.
- Growth Conditions can be loaded from DatasetMetadata file and can handle arrays of GC.
- Some readed files starts with an empty colum, FIXED.
- Experiments IDs can be readed correctly.
- Peaks score property error in reading, FIXED.
- NLP Growth Conditions, adjust to have more than one term.

### Deprecated

- Without changes.

### Removed

- Without changes.

### Fixed

- Without changes.

### Security

- Without changes.
